### PR TITLE
Zip application/json responses

### DIFF
--- a/Sources/GzipMiddleware/GzipMiddleware.swift
+++ b/Sources/GzipMiddleware/GzipMiddleware.swift
@@ -42,7 +42,7 @@ extension Request {
 extension Response {
     var gzippable: Bool {
         guard let contentType = contentType else { return false }
-        if contentType.contains("text/html") || contentType.contains("application/javascript") || contentType.contains("text/css") {
+        if contentType.contains("text/html") || contentType.contains("application/javascript")  || contentType.contains("application/json") || contentType.contains("text/css") {
             return true
         }
         return false


### PR DESCRIPTION
Add support for gzipping responses with a Content-Type of application/json (which is the Content-Type set by Vapor's JSON().